### PR TITLE
(#16) Check to see if we can also obtain the author's name

### DIFF
--- a/src/main/resources/xsd/schema.xsd
+++ b/src/main/resources/xsd/schema.xsd
@@ -49,11 +49,8 @@
   <xsd:element name="author">
     <xsd:complexType>
       <xsd:sequence>
-        <!--
-         @todo #14:15min Check to see if we can also obtain the author's full
-          name here. If we can, add another element to the sequence.
-        -->
-        <xsd:element name="login" type="xsd:string"/>
+        <xsd:element name="name" type="xsd:string"/>
+        <xsd:element name="email" type="xsd:string"/>
       </xsd:sequence>
     </xsd:complexType>
   </xsd:element>


### PR DESCRIPTION
`author/login` was removed. Linking commits to github logins is unique to github - see https://help.github.com/articles/why-are-my-commits-linked-to-the-wrong-user/.

Therefore, `author/name` and `author/email` were added.